### PR TITLE
Use tape directly instead of prova

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-config-airbnb": "^1.0.0",
     "marked-man": "^0.1.5",
     "node-dev": "github:tomekwi/node-dev#39f8c44",
-    "prova": "^2.1.2",
+    "tape": "^4.5.0",
     "proxyquire": "^1.7.4",
     "strip-ansi": "^3.0.0"
   }

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 
-const test = require('prova');
+const test = require('tape');
 const proxyquire = require('proxyquire').noPreserveCache().noCallThru();
 const devnull = require('dev-null');
 const qs = require('q-stream');


### PR DESCRIPTION
Fixes #8

I've found that you can use tape directly instead of using the version embedded in prova.  Feel free to ignore this PR if you have other parts of prova that you're using or some other path forward on this.

Hope it helps!