### PR TITLE
Replace gaze with chokidar

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "dependencies": {
     "budo": "^8.0.4",
     "chalk": "^1.1.1",
+    "chokidar": "^1.4.3",
     "cross-spawn": "^2.1.5",
-    "gaze": "^1.0.0",
     "indent-string": "^2.1.0",
     "q-stream": "^0.2.0"
   },

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -112,7 +112,7 @@ ${ indent(String(elmMake.error), '  ') }
   }
 
   // Watch Elm files
-  const watcher = chokidar.watch('**/*.elm', { ignoreInitial: false, ignorePermissionErrors: true });
+  const watcher = chokidar.watch('**/*.elm', { ignoreInitial: true, ignorePermissionErrors: true });
 
   watcher.on('all', (event, filePath) => {
     const relativePath = path.relative(process.cwd(), filePath);

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 const indent = require('indent-string');
 const budo = require('budo');
-const gaze = require('gaze');
+const chokidar = require('chokidar');
 const chalk = require('chalk');
 const bold = chalk.bold;
 const dim = chalk.dim;
@@ -112,24 +112,22 @@ ${ indent(String(elmMake.error), '  ') }
   }
 
   // Watch Elm files
-  gaze('**/*.elm', (error, watcher) => {
-    if (error) throw error;
+  const watcher = chokidar.watch('**/*.elm', { ignoreInitial: false, ignorePermissionErrors: true });
 
-    watcher.on('all', (event, filePath) => {
-      const relativePath = path.relative(process.cwd(), filePath);
+  watcher.on('all', (event, filePath) => {
+    const relativePath = path.relative(process.cwd(), filePath);
 
-      outputStream.write(
+    outputStream.write(
 `\n${ dim('elm-live:') }
   You’ve ${ event } \`${ relativePath }\`. Rebuilding!
 
 `
-      );
+    );
 
-      const buildResult = build();
-      if (!serverStarted && buildResult.exitCode === SUCCESS) {
-        startServer();
-      }
-    });
+    const buildResult = build();
+    if (!serverStarted && buildResult.exitCode === SUCCESS) {
+      startServer();
+    }
   });
 
   return null;

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -112,7 +112,7 @@ ${ indent(String(elmMake.error), '  ') }
   }
 
   // Watch Elm files
-  const watcher = chokidar.watch('**/*.elm', { ignoreInitial: true, ignorePermissionErrors: true });
+  const watcher = chokidar.watch('**/*.elm', { ignoreInitial: true });
 
   watcher.on('all', (event, filePath) => {
     const relativePath = path.relative(process.cwd(), filePath);

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -111,15 +111,24 @@ ${ indent(String(elmMake.error), '  ') }
     startServer();
   }
 
+  const eventNameMap = {
+    'add': 'added',
+    'addDir': 'added',
+    'change': 'changed',
+    'unlink': 'removed',
+    'unlinkDir': 'removed',
+  };
+
   // Watch Elm files
   const watcher = chokidar.watch('**/*.elm', { ignoreInitial: true });
 
   watcher.on('all', (event, filePath) => {
     const relativePath = path.relative(process.cwd(), filePath);
+    const eventName = eventNameMap[event] || event;
 
     outputStream.write(
 `\n${ dim('elm-live:') }
-  You’ve ${ event } \`${ relativePath }\`. Rebuilding!
+  You’ve ${ eventName } \`${ relativePath }\`. Rebuilding!
 
 `
     );

--- a/test.js
+++ b/test.js
@@ -397,7 +397,7 @@ test('Serves at the specified `--port`', (assert) => {
 test((
   'Watches all `**/*.elm` files in the current directory'
 ), (assert) => new Promise((resolve) => {
-  assert.plan(4);
+  assert.plan(5);
 
   const event = 'touched';
   const relativePath = path.join('ab', 'c.elm');
@@ -410,10 +410,12 @@ test((
   };
 
   const chokidar = {
-    watch: (target) => {
+    watch: (target, options) => {
       assert.is(target, '**/*.elm',
         'passes the right glob to chokidar'
       );
+
+      assert.true(options.ignoreInitial, 'does not trigger events when starting watch');
 
       return watcherMock;
     },

--- a/test.js
+++ b/test.js
@@ -399,7 +399,7 @@ test((
 ), (assert) => new Promise((resolve) => {
   assert.plan(5);
 
-  const event = 'touched';
+  const event = 'change';
   const relativePath = path.join('ab', 'c.elm');
   const absolutePath = path.resolve(process.cwd(), relativePath);
 
@@ -458,7 +458,7 @@ test((
 
     const expectedMessage = (
 `\nelm-live:
-  You’ve ${ event } \`${ relativePath }\`. Rebuilding!
+  You’ve changed \`${ relativePath }\`. Rebuilding!
 
 `
     );


### PR DESCRIPTION
Replacing gaze with the watcher from budo, chokidar, appears to fix the performance issue that was seen on Windows.  Because gaze was blocking when it started up, budo couldn't serve its files until gaze had finished finding all the elm files.  Even if I waited for budo to start before kicking gaze off, it still stalled budo from being able to reload (and there wasn't a good event to use for triggering gaze, so it would have used an arbitrary timeout value).

Using chokidar, which does its file finding asynchronously, there is no visible contention between the watcher and the server.  Additionally, making a change right after starting the server starts is seen and recompiled, without any significant delay from the watcher.

Fixes #11