### PR TITLE
Remove peerDependencies on elm

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "indent-string": "^2.1.0",
     "q-stream": "^0.2.0"
   },
-  "peerDependencies": {
-    "elm": "*"
-  },
   "scripts": {
     "develop": "ava --watch",
     "manpages": "scripts/manpages.sh",


### PR DESCRIPTION
This fixes a contradiction with the README. 😃 

```
If you’d rather bring your own global `elm-make`, `npm install --global elm-live` will do.
```

It currently isn't possible to bring your own global `elm-make` because of the `peerDependency` on `elm`. This recently prevented me from doing `npm install -g elm@alpha` alongside my existing `elm-live` installation:
```
npm ERR! Darwin 15.3.0
npm ERR! argv "/usr/local/Cellar/node/4.2.1/bin/node" "/usr/local/bin/npm" "install" "-g" "elm@alpha"
npm ERR! node v4.2.1
npm ERR! npm  v2.14.7
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package elm@0.17.0-alpha2 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer elm-live@2.0.4 wants elm@*

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/rtfeldman/Downloads/npm-debug.log
```

Honestly I think it's better off without this anyway, considering with this `peerDependency` it's not possible to use `elm-live` if you've installed Elm via the installers on the website, which seems unnecessarily restrictive.