### PR TITLE
Added --host option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -86,6 +86,9 @@ We also watch all `*.elm` files in the current directory and its subdirectories.
 #### `--port=PORT`
 Set the port to start the server at. If the port is taken, we’ll use the next available one. `PORT` should be a valid port number. Default: `8000`.
 
+#### `--host=HOSTNAME|IP`
+Set the host interface to attach the server to. Default: `localhost`.
+
 #### `--open`
 We’ll open the app in your default browser as soon as the server is up.
 

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -107,6 +107,7 @@ ${indent(String(elmMake.error), '  ')}
       live: true,
       watchGlob: '**/*.{html,css,js}',
       port: args.port,
+      host: args.host,
       open: args.open,
       stream: outputStream,
     });

--- a/source/parse-args.js
+++ b/source/parse-args.js
@@ -3,6 +3,7 @@ const defaults = {
   open: false,
   help: false,
   recover: true,
+  host: 'localhost',
 };
 
 module.exports = (argv) => {
@@ -31,6 +32,13 @@ module.exports = (argv) => {
     const portMatch = arg.match(portPattern);
     if (portMatch) {
       args.port = Number(portMatch[1]);
+      return true;
+    }
+
+    const hostPattern = /^--host=(.*)$/;
+    const hostMatch = arg.match(hostPattern);
+    if (hostMatch) {
+      args.host = hostMatch[1];
       return true;
     }
 

--- a/test.js
+++ b/test.js
@@ -409,11 +409,15 @@ How’s it going?
 
 
 test('Starts budo and chokidar with correct config', (assert) => {
-  assert.plan(5);
+  assert.plan(6);
 
   const budo = (options) => {
     assert.is(options.port, 8000,
       'uses port 8000 by default (or the next available one)'
+    );
+
+    assert.is(options.host, 'localhost',
+      'uses the localhost interface by default'
     );
 
     assert.is(options.open, false,

--- a/test.js
+++ b/test.js
@@ -490,6 +490,28 @@ test('Serves at the specified `--port`', (assert) => {
 });
 
 
+test('Serves on the specified `--host` or `-H`', (assert) => {
+  assert.plan(2);
+
+  const hostName1 = 'localhost';
+  const hostName2 = '127.0.0.1';
+
+  const budo = (options) => {
+    assert.true(options.host === hostName1 || options.host === hostName2,
+      'passes `--host` or `-H` to budo'
+    );
+
+    return dummyBudoServer;
+  };
+
+  const elmLive = proxyquire('./source/elm-live', {
+    budo, chokidar: dummyChokidar, 'cross-spawn': dummyCrossSpawn,
+  });
+
+  elmLive([`--host=${hostName1}`], dummyConfig);
+  elmLive([`--host=${hostName2}`], dummyConfig);
+});
+
 test((
   'Watches all `**/*.elm` files in the current directory'
 ), (assert) => new Promise((resolve) => {


### PR DESCRIPTION
While running my VPN client and elm-live, elm-live was attaching to my VPN interface instead of localhost. This option allows the host interface to be explicitly set and it defaults to localhost without the option.