### PR TITLE
Add --pushstate

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -101,6 +101,9 @@ We’ll open the app in your default browser as soon as the server is up.
 #### `--no-recover`
 When _elm-make_ encounters a compile error, we keep _elm-live_ running and give you time to fix your code. Pass `--no-recover` if you want the server to exit immediately whenever it encounters a compile error.
 
+#### `--pushstate`
+Serve `index.html` on 404 errors. This lets us use client-side routing in Elm. For instance, we can have a URL like `http://localhost:8000/account` get handled by the Elm _navigation_ package instead of failing with a 404 error.
+
 #### `--help`
 You’re looking at it.
 
@@ -128,7 +131,11 @@ $ echo \
 $ elm-live Main.elm --output=elm.js --open
 ```
 
+Support client-side routing in Elm:
 
+```sh
+$ elm-live Main.elm --open --pushstate
+```
 
 
 <a id="/caveats"></a>&nbsp;

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -111,7 +111,7 @@ ${indent(String(elmMake.error), 2)}
       open: args.open,
       dir: args.dir,
       stream: outputStream,
-      pushstate: args.pushstate
+      pushstate: args.pushstate,
     });
     server.on('error', (error) => { throw error; });
 

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -111,6 +111,7 @@ ${indent(String(elmMake.error), 2)}
       open: args.open,
       dir: args.dir,
       stream: outputStream,
+      pushstate: args.pushstate
     });
     server.on('error', (error) => { throw error; });
 

--- a/source/parse-args.js
+++ b/source/parse-args.js
@@ -6,7 +6,7 @@ const defaults = {
   pathToElmMake: 'elm-make',
   host: 'localhost',
   dir: '.',
-  pushstate: false
+  pushstate: false,
 };
 
 module.exports = (argv) => {

--- a/source/parse-args.js
+++ b/source/parse-args.js
@@ -6,6 +6,7 @@ const defaults = {
   pathToElmMake: 'elm-make',
   host: 'localhost',
   dir: '.',
+  pushstate: false
 };
 
 module.exports = (argv) => {
@@ -20,7 +21,7 @@ module.exports = (argv) => {
       }
       return false;
     };
-    if (['help', 'open'].some(tryBoolOption)) {
+    if (['help', 'open', 'pushstate'].some(tryBoolOption)) {
       return true;
     }
 

--- a/test.js
+++ b/test.js
@@ -428,7 +428,7 @@ How’s it going?
 
 
 test('Starts budo and chokidar with correct config', (assert) => {
-  assert.plan(7);
+  assert.plan(8);
 
   const budo = (options) => {
     assert.is(options.port, 8000,
@@ -449,6 +449,10 @@ test('Starts budo and chokidar with correct config', (assert) => {
 
     assert.is(options.watchGlob, '**/*.{html,css,js}',
       'reloads the app when an HTML, JS or CSS static file changes'
+    );
+
+    assert.is(options.pushstate, false,
+      'disables `--pushstate` by default'
     );
 
     assert.is(options.stream, dummyConfig.outputStream,
@@ -562,6 +566,23 @@ test('Serves from the specified `--dir`', (assert) => {
   elmLive([`--dir=${dir}`], dummyConfig);
 });
 
+test('`--pushstate to support client-side routing', (assert) => {
+  assert.plan(1);
+
+  const budo = (options) => {
+    assert.is(options.pushstate, true,
+      'passes `--pushstate` to budo'
+    );
+
+    return dummyBudoServer;
+  };
+
+  const elmLive = proxyquire('./source/elm-live', {
+    budo, chokidar: dummyChokidar, 'cross-spawn': dummyCrossSpawn,
+  });
+
+  elmLive(['--pushstate'], dummyConfig);
+});
 
 test((
   'Watches all `**/*.elm` files in the current directory'


### PR DESCRIPTION
When you try to use client-side routing via the Elm _navigation_ and _url-parser_ packages, _elm-live_ will try to find static files for the URL path. For example, if our URL is `http://localhost:8000/accounts`, _elm-live_ will look for an `accounts.html` file in the `static` directory.

By adding the `--pushstate` flag, we can get _elm-live_ to route to `index.html` on 404 errors and client-side routing will work.