### PR TITLE
Create before-build option to run external commands

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -104,6 +104,12 @@ When _elm-make_ encounters a compile error, we keep _elm-live_ running and give 
 #### `--pushstate`
 Serve `index.html` on 404 errors. This lets us use client-side routing in Elm. For instance, we can have a URL like `http://localhost:8000/account` get handled by the Elm _navigation_ package instead of failing with a 404 error.
 
+#### `--before-build`
+Run a command before a build is run. This allows us to call external build tools that could generate Elm code, for example.
+
+#### `--after-build`
+Run a command after a build finishes. The same as `--before-build`, but it runs after the build finishes. We can then execute a command that depends on the finished source.
+
 #### `--help`
 You’re looking at it.
 

--- a/Readme.md
+++ b/Readme.md
@@ -107,9 +107,6 @@ Serve `index.html` on 404 errors. This lets us use client-side routing in Elm. F
 #### `--before-build`
 Run a command before a build is run. This allows us to call external build tools that could generate Elm code, for example.
 
-#### `--after-build`
-Run a command after a build finishes. The same as `--before-build`, but it runs after the build finishes. We can then execute a command that depends on the finished source.
-
 #### `--help`
 You’re looking at it.
 

--- a/Readme.md
+++ b/Readme.md
@@ -105,7 +105,9 @@ When _elm-make_ encounters a compile error, we keep _elm-live_ running and give 
 Serve `index.html` on 404 errors. This lets us use client-side routing in Elm. For instance, we can have a URL like `http://localhost:8000/account` get handled by the Elm _navigation_ package instead of failing with a 404 error.
 
 #### `--before-build`
-Run a command before a build is run. This allows us to call external build tools that could generate Elm code, for example.
+Run an executable before every rebuild. This way you can easily use other tools like elm-css or browserify in your workflow.
+
+Heads up! At the moment, we only allow running a single executable without parameters. If you need more than that, please give us a shout at https://git.io/elm-live.before-build-args.
 
 #### `--help`
 You’re looking at it.

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -54,7 +54,7 @@ module.exports = (argv, options) => {
 
   const auxiliaryBuild = (execPath) => {
     if (!execPath) {
-      return { fatal: false, status: SUCCESS };
+      return { fatal: false, exitCode: SUCCESS };
     }
 
     const process = spawnSync(execPath, [], {

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -134,13 +134,6 @@ ${indent(String(elmMake.error), 2)}
 `
     );
 
-    if (elmMake.status === SUCCESS) {
-      const afterBuild = auxiliaryBuild(args.afterBuild);
-      if (afterBuild.status !== SUCCESS) {
-        return afterBuild;
-      }
-    }
-
     return { fatal: false, exitCode: elmMake.status };
   };
 

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -94,7 +94,7 @@ module.exports = (argv, options) => {
   // Build logic
   const build = () => {
     const beforeBuild = auxiliaryBuild(args.beforeBuild);
-    if (beforeBuild.status !== SUCCESS) {
+    if (beforeBuild.exitCode !== SUCCESS) {
       return beforeBuild;
     }
 

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -52,20 +52,20 @@ module.exports = (argv, options) => {
     return SUCCESS;
   }
 
-  const auxiliaryBuild = (path) => {
-    if(!path) {
+  const auxiliaryBuild = (execPath) => {
+    if (!execPath) {
       return { fatal: false, status: SUCCESS };
     }
 
-    const process = spawnSync(path, [], {
+    const process = spawnSync(execPath, [], {
       stdio: [inputStream, outputStream, outputStream],
     });
 
-    if(process.error && process.error.code === 'ENOENT') {
+    if (process.error && process.error.code === 'ENOENT') {
       outputStream.write(
   `\n${dim('elm-live:')}
-    I am trying to run ${bold(path)} but can't find it!
-    Please make sure you can call ${bold(path)}
+    I am trying to run ${bold(execPath)} but can't find it!
+    Please make sure you can call ${bold(execPath)}
     from your command line.
   `
       );
@@ -73,8 +73,8 @@ module.exports = (argv, options) => {
       return { fatal: true, exitCode: FAILURE };
     } else if (process.error) {
       outputStream.write(
-  `\n${dim('elm-live:')} Error while calling ${bold(path)}! This output may be helpful:
-  ${indent(String(command.error), 2)}
+  `\n${dim('elm-live:')} Error while calling ${bold(execPath)}! This output may be helpful:
+  ${indent(String(process.error), 2)}
 
   `
       );
@@ -82,20 +82,19 @@ module.exports = (argv, options) => {
 
     if (args.recover && process.status !== SUCCESS) outputStream.write(
 `\n${dim('elm-live:')}
-  ${bold(path)} failed! You can find more info above. Keep calm and take your time
+  ${bold(execPath)} failed! You can find more info above. Keep calm and take your time
   to fix your code. We’ll try to compile it again as soon as you change a file.
 
 `
     );
-    
+
     return { fatal: false, exitCode: process.status };
-  }
+  };
 
   // Build logic
   const build = () => {
-
     const beforeBuild = auxiliaryBuild(args.beforeBuild);
-    if(beforeBuild.status !== SUCCESS) {
+    if (beforeBuild.status !== SUCCESS) {
       return beforeBuild;
     }
 
@@ -135,9 +134,9 @@ ${indent(String(elmMake.error), 2)}
 `
     );
 
-    if(elmMake.status === SUCCESS) {
+    if (elmMake.status === SUCCESS) {
       const afterBuild = auxiliaryBuild(args.afterBuild);
-      if(afterBuild.status !== SUCCESS) {
+      if (afterBuild.status !== SUCCESS) {
         return afterBuild;
       }
     }

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -67,6 +67,7 @@ module.exports = (argv, options) => {
   I can’t find the command ${bold(execPath)}!
   Please make sure you can call ${bold(execPath)}
   from your command line.
+
 `
       );
 
@@ -82,8 +83,8 @@ ${indent(String(process.error), 2)}
 
     if (args.recover && process.status !== SUCCESS) outputStream.write(
 `\n${dim('elm-live:')}
-  ${bold(execPath)} failed! You can find more info above. Keep calm and take your time
-  to fix your code. We’ll try to compile it again as soon as you change a file.
+  ${bold(execPath)} failed! You can find more info above. Keep calm and take your time 
+  to check why the command is failing. We’ll try to run it again as soon as you change an Elm file.
 
 `
     );

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -83,7 +83,7 @@ ${indent(String(process.error), 2)}
 
     if (args.recover && process.status !== SUCCESS) outputStream.write(
 `\n${dim('elm-live:')}
-  ${bold(execPath)} failed! You can find more info above. Keep calm and take your time 
+  ${bold(execPath)} failed! You can find more info above. Keep calm and take your time
   to check why the command is failing. We’ll try to run it again as soon as you change an Elm file.
 
 `

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -73,10 +73,10 @@ module.exports = (argv, options) => {
       return { fatal: true, exitCode: FAILURE };
     } else if (process.error) {
       outputStream.write(
-  `\n${dim('elm-live:')} Error while calling ${bold(execPath)}! This output may be helpful:
-  ${indent(String(process.error), 2)}
+`\n${dim('elm-live:')} Error while calling ${bold(execPath)}! This output may be helpful:
+${indent(String(process.error), 2)}
 
-  `
+`
       );
     }
 

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -63,11 +63,11 @@ module.exports = (argv, options) => {
 
     if (process.error && process.error.code === 'ENOENT') {
       outputStream.write(
-  `\n${dim('elm-live:')}
-    I am trying to run ${bold(execPath)} but can't find it!
-    Please make sure you can call ${bold(execPath)}
-    from your command line.
-  `
+`\n${dim('elm-live:')}
+  I can’t find the command ${bold(execPath)}!
+  Please make sure you can call ${bold(execPath)}
+  from your command line.
+`
       );
 
       return { fatal: true, exitCode: FAILURE };

--- a/source/parse-args.js
+++ b/source/parse-args.js
@@ -50,6 +50,8 @@ module.exports = (argv) => {
       { arg: '--host', key: 'host' },
       { arg: '--path-to-elm-make', key: 'pathToElmMake' },
       { arg: '--dir', key: 'dir' },
+      { arg: '--before-build', key: 'beforeBuild' },
+      { arg: '--after-build', key: 'afterBuild' }
     ].some(tryStringOption)) {
       return true;
     }

--- a/source/parse-args.js
+++ b/source/parse-args.js
@@ -51,7 +51,7 @@ module.exports = (argv) => {
       { arg: '--path-to-elm-make', key: 'pathToElmMake' },
       { arg: '--dir', key: 'dir' },
       { arg: '--before-build', key: 'beforeBuild' },
-      { arg: '--after-build', key: 'afterBuild' }
+      { arg: '--after-build', key: 'afterBuild' },
     ].some(tryStringOption)) {
       return true;
     }

--- a/source/parse-args.js
+++ b/source/parse-args.js
@@ -51,7 +51,6 @@ module.exports = (argv) => {
       { arg: '--path-to-elm-make', key: 'pathToElmMake' },
       { arg: '--dir', key: 'dir' },
       { arg: '--before-build', key: 'beforeBuild' },
-      { arg: '--after-build', key: 'afterBuild' },
     ].some(tryStringOption)) {
       return true;
     }

--- a/test.js
+++ b/test.js
@@ -735,7 +735,7 @@ test((
       (
 `\nelm-live:
   ${beforeCommand} failed! You can find more info above. Keep calm and take your time
-  to fix your code. We’ll try to compile it again as soon as you change a file.
+  to check why the command is failing. We’ll try to run it again as soon as you change an Elm file.
 
 `
       ),

--- a/test.js
+++ b/test.js
@@ -680,7 +680,7 @@ test((
 ), (assert) => new Promise((resolve) => {
   const beforeCommand = 'testCommand';
 
-  const commandsRun = []; 
+  const commandsRun = [];
 
   const crossSpawn = { sync: (command) => {
     commandsRun.push(command);

--- a/test.js
+++ b/test.js
@@ -674,3 +674,31 @@ test((
     }),
   });
 }));
+
+test((
+  '--before-build runs command'
+), (assert) => new Promise((resolve) => {
+  const beforeCommand = 'testCommand';
+
+  const commandsRun = []; 
+
+  const crossSpawn = { sync: (command) => {
+    commandsRun.push(command);
+    return dummyCrossSpawn.sync();
+  } };
+
+  const elmLive = proxyquire('./source/elm-live', { 'cross-spawn': crossSpawn });
+
+  elmLive([`--before-build=${beforeCommand}`], dummyConfig);
+
+  assert.deepEqual(
+    commandsRun,
+    [
+      beforeCommand,
+      'elm-make',
+    ],
+    'Calls the `--before-build` command and `elm-make`'
+  );
+
+  resolve();
+}));


### PR DESCRIPTION
Adds two arguments to elm-live, `--before-build` and `--after-build`. These arguments allow running external build tools before (e.g. code generators) as well as after (e.g. bundlers) the elm-make build.

This will resolve #67.

## Progress
- [x] Add option documentation to the fields.
- [x] Add options to the argument parser.
- [x] Modify build function to run the supplied commands
- [x] Write tests.

Feedback, especially concerning wording of messages is very welcome.

There is still some discussion necessary regarding how to spawn the commands. I would appreciate your input @bdukes :)