### PR TITLE
stop watching elm-test generated code

### DIFF
--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -194,7 +194,7 @@ ${indent(String(elmMake.error), 2)}
   };
 
   // Watch Elm files
-  const watcher = chokidar.watch('**/*.elm', { ignoreInitial: true, followSymlinks: false });
+  const watcher = chokidar.watch('**/*.elm', { ignoreInitial: true, followSymlinks: false, ignored: "elm-stuff/generated-code/*" });
 
   watcher.on('all', debounce((event, filePath) => {
     const relativePath = path.relative(process.cwd(), filePath);


### PR DESCRIPTION
Right now if you have elm-test watching and elm-live watching, elm-live ends up restarting a whole bunch of times from the changes that elm-test makes in elm-stuff/generated-code.