### PR TITLE
Downgrade chokidar to fix overzealous watching

### DIFF
--- a/Changelog.yaml
+++ b/Changelog.yaml
@@ -1,3 +1,7 @@
+master:
+  fixed bugs:
+    - Prevented some cases where changes to non-Elm files got picked up.
+
 2.7.4:
   date: 2017-01-11
   fixed bugs:


### PR DESCRIPTION
As described in detail in https://github.com/paulmillr/chokidar/issues/544, all versions of chokidar higher than 1.6.1 unexpectedly pick up changes to symlinks. We want to lock down the version of chokidar until they fix the issue.

Fixes #103 
